### PR TITLE
Remove Semesters Button Support:

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,15 +7,16 @@ import MajorDropdown from './components/MajorDropdown'
 function App() {
     //Basic year setup, organized by Year Name, the semesters (semester name, then courses, (course name))
     const [years, setYears] = useState([
-        { name: "Year 1", semesters: [{ name: "Fall", courses: [] }, { name: "Spring", courses: [] }] },
-        { name: "Year 2", semesters: [{ name: "Fall", courses: [] }, { name: "Spring", courses: [] }] },
-        { name: "Year 3", semesters: [{ name: "Fall", courses: [] }, { name: "Spring", courses: [] }] },
-        { name: "Year 4", semesters: [{ name: "Fall", courses: [] }, { name: "Spring", courses: [] }] },
+        { name: "Before UMBC", preUMBC: true, semesters: [{ name: "Test Credit", courses: []}, { name: "Transfer Credit", courses: [] }] },
+        { name: "Year 1", preUMBC: false, semesters: [{ name: "Fall", courses: [] }, { name: "Spring", courses: [] }] },
+        { name: "Year 2", preUMBC: false, semesters: [{ name: "Fall", courses: [] }, { name: "Spring", courses: [] }] },
+        { name: "Year 3", preUMBC: false, semesters: [{ name: "Fall", courses: [] }, { name: "Spring", courses: [] }] },
+        { name: "Year 4", preUMBC: false, semesters: [{ name: "Fall", courses: [] }, { name: "Spring", courses: [] }] },
     ]);
     //Adds basic empty year object
     const addYear = () => {
         const newYear = years.length + 1;
-        setYears([...years, { name: "Year " + newYear, semesters: [{ name: "Fall", courses: [] }, { name: "Spring", courses: [] }] }]);
+        setYears([...years, { name: "Year " + newYear, preUMBC: false, semesters: [{ name: "Fall", courses: [] }, { name: "Spring", courses: [] }] }]);
  
     };
     //Use for the credit range checks
@@ -90,6 +91,12 @@ function App() {
         );
     };
 
+    const removeYear = (yearName) => {
+        setYears(newYears => years.filter(
+            (year) => year.name !== yearName
+        ))
+    }
+
     return (
         <div className="flex flex-col ml-4 mr-4" data-testid="callYear">
 
@@ -110,13 +117,22 @@ function App() {
           <div className="flex flex-col justify-center items-center min-h-screen" key="year">
           
               {
-                  years.map((year) => {     
+                  years.map((year, index) => {     
                       return (
-                          <Year name={year.name} semesters={year.semesters} removeFromSemester={removeFromSemester} updateYear={ updateYear} className="flex-grow w-full" key={year.name} />
+                          <Year name = {index === 0 ? "Before UMBC" : `Year ${index}`} 
+                              removeYear={removeYear }
+                              preUMBC={year.preUMBC}
+                              semesters={year.semesters}
+                              removeFromSemester={removeFromSemester}
+                              updateYear={updateYear}
+                              className="flex-grow w-full"
+                              key={year.name}
+                          />
 
                       );
                   })
                 }
+                
           </div>
             
             <button onClick={addYear} className="px-6 py-2 bg-blue-500 text-white font-semibold rounded-lg shadow-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50">

--- a/src/components/Course.js
+++ b/src/components/Course.js
@@ -10,13 +10,13 @@ function Course(props) {
     }
 
     return (
-        <div className="relative bg-white border border-gray-300 rounded-sm shadow-md space-y-2  flex-grow w-full max-h-sm"
+        <div className="relative bg-white border border-gray-300 rounded-lg shadow-md space-y-2  flex-grow w-full max-h-sm"
             //Needed for drag and drop functionality
             draggable
             onDragStart={ onDragStart}
         >
             <p className="text- font-semibold">{props.name}</p>
-            <button className= "absolute top-0 right-0 bg-gray-100 text- font-semibold border border border-gray-300 rounded-sm shadow-md hover:text-red-600"
+            <button className= "absolute top-0 right-0 text-right font-semibold hover:text-red-600"
                  onClick= {props.remove}> 
                  X
             </button>

--- a/src/components/Semester.js
+++ b/src/components/Semester.js
@@ -1,17 +1,17 @@
 import Course from './Course';
 import EditCourse from './EditCourse';
-
+import { v4 as uuid } from "uuid";
 
 function Semester(props) {
     //Promote prop details to variables
-    const {courses } = props;
+    const {name, courses } = props;
     
     const addCourse = (newCourse) => { //newcourses is a prop sent to editCourses and it comes back witht e selected course name 
         
         // get whats in courses and add a new course to it and the number of courses
-        const newCourses = [...courses, { name: newCourse }];
+        const newCourses = [...courses, { name: newCourse, key: uuid() }];
         //CALLBACK FUNCTION
-        props.updateSemester({ name: props.name, courses: newCourses });
+        props.updateSemester({ name: props.name, courses: newCourses, preUMBC: props.preUMBC  });
     }
 
     const removeCourse = (index) => {//index is the index in the courses array to remove
@@ -51,21 +51,32 @@ function Semester(props) {
             onDragOver={handleDragOver }
         >
             <div className="m-2 space-y-0.5">
-                <p className="text-lg font-semibold text-black">{props.name}</p> {/*display semester name */}
+                <div className="relative">
+                    <p className="text-lg font-semibold text-black">{name}</p> {/*display semester name */}
+                    {
+                        //Necessary for hiding the button if pre-umbc year
+                        !props.preUMBC && <button
+                            className="absolute top-0 right-0 text-right font-semibold  hover:text-red-600"
+                            onClick={() => props.removeSemester(name)}>
+                            X
+                        </button>
+                    }
+                </div>
                         
                 <div className="flex flex-col justify-center items-center">
 
                     {
                         courses.map((course, i) => { //iterates through courses and lists their name
                             return (
-                                <Course key={course.name} name={course.name} semesterName={props.name} yearName={ props.yearName} remove={() => removeCourse(i)}/>
+                                <Course key={uuid()} name={course.name} semesterName={name} yearName={ props.yearName} remove={() => removeCourse(i)}/>
 
                             );
                         })
                     }
                 </div>
                 
-                <EditCourse onConfirm={addCourse}/> {/* call the component which handles listing course options and adding the selected course*/} 
+                <EditCourse onConfirm={addCourse} /> {/* call the component which handles listing course options and adding the selected course*/} 
+                
             </div>
         </div>
 

--- a/src/components/Year.js
+++ b/src/components/Year.js
@@ -1,35 +1,81 @@
 import Semester from './Semester';
 import Button from 'react-bootstrap/Button';
-
+import {useState} from "react";
 function Year(props) {
-    const { semesters } = props;
 
-    const addSemester = () => {
-        const newSemNum = semesters.length + 1;
+    //establish variables without having to use props.x 
+    const { preUMBC, semesters } = props;
+
+    //boolean varaibles for showing the add semester buttons
+    const [fall, setFall] = useState(false); //dont show on default
+    const [spring, setSpring] = useState(false); //dont show on default
+    const [winter, setWinter] = useState(preUMBC ? false : true); //show only if not preUMBC year
+    const [summer, setSummer] = useState(preUMBC ? false : true); //show only if not preUMBC year
+
+    const addSemester = (semesterID) => {
+        const newSemNum = semesterID + 1;
         //Don't add any semesters past summer
         if (newSemNum === 5) return;
 
         let newSem;
-        if (newSemNum === 1) newSem = { name: "Fall", courses: []};
-        else if (newSemNum === 2) newSem = { name: "Spring", courses: [] };
-        else if (newSemNum === 3) newSem = { name: "Winter", courses: [] };
-        else if (newSemNum === 4) newSem = { name: "Summer", courses: [] };
-
+        //update newsem to pass upwards and set the button hide boolean
+        if (newSemNum === 1) {
+            newSem = { name: "Fall", courses: [] };
+            setFall(false);
+        }
+        else if (newSemNum === 2) {
+            newSem = { name: "Spring", courses: [] };
+            setSpring(false);
+        }
+        else if (newSemNum === 3) {
+            newSem = { name: "Winter", courses: [] };
+            setWinter(false);
+        }
+        else if (newSemNum === 4) {
+            newSem = { name: "Summer", courses: [] };
+            setSummer(false);
+        }
+        //add the new sem on before sorting
         const updatedSemesters = [...semesters, newSem];
 
-        //Assign
+        //Assign orders
         const order = { "Fall": 1, "Winter": 2, "Spring": 3, "Summer": 4 };
 
         // Sort the semesters based on the order
         updatedSemesters.sort((a, b) => order[a.name] - order[b.name]);
 
-        props.updateYear({ name: props.name, semesters: updatedSemesters });
+        //pass back the updated list of semesters to app.js to format
+        props.updateYear({ name: props.name, semesters: updatedSemesters, preUMBC: props.preUMBC });
     };
 
     const updateSemester = (newSem) => {
         const newSems = semesters.map(sem =>
             sem.name === newSem.name ? newSem : sem
         );
+        props.updateYear({ name: props.name, semesters: newSems, preUMBC: props.preUMBC });
+    }
+    //Function for when the x is clicked on a semester, is a callback function used by semester
+    const removeSemester = (semName) => {
+
+        //Remove the desired semester
+        const newSems = semesters.filter(
+            (sem) => sem.name !== semName
+        )
+
+        //Show the correct button to allow for the user to add the semester back
+        if (semName === "Fall") {
+            setFall(true);
+        }
+        else if (semName === "Spring") {
+            setSpring(true);
+        }
+        else if (semName === "Winter") {
+            setWinter(true);
+        }
+        else if (semName === "Summer") {
+            setSummer(true);
+        }
+        //Pass back changes to the year's semester to app.js
         props.updateYear({ name: props.name, semesters: newSems });
     }
 
@@ -37,26 +83,71 @@ function Year(props) {
         <div className="m-1 py-8 px-8 w-full space-y-2 border border-gray-300 bg-white rounded-xl shadow-md sm:py-2 sm:flex sm:items-center sm:space-y-0 sm:gap-x-6">
             <div className="space-y-2 text-center sm:text-left w-full">
                 <div className="space-y-0.35">
+                    <div className="relative">
                     <p className="text-lg font-semibold text-black text-center ">{props.name}</p>
+                        {/*
+                            //Necessary for hiding the button if pre-umbc year
+                            !preUMBC && <button
+                                className="absolute top-0 right-0 text- font-semibold  hover:text-red-600"
+                                onClick={() => props.removeYear(props.name)}>
+                                X
+                            </button>
+                        */}
+                    </div>
                     <div className="m-2 border border-gray-300 rounded-xl py-6 px-4 w-full space-y-2 bg-white rounded-xlsm:py-4 sm:flex sm:items-center sm:space-y-0 sm:gap-x-6">
+                        
+                        {
+                            //Only show the "add semester" message if no semesters are present
+                            (!preUMBC && fall && spring && winter && summer) && <button className="w-full text-center">Click one of the add semester buttons below!</button>
+                        }
+                        
                         {/* Make Semesters take equal width */}
                         {
                             semesters.map((sem) => {
                                 return (
+                                    
                                     <Semester key={sem.name}
                                         name={sem.name}
                                         courses={sem.courses}
                                         yearName={props.name}
                                         removeFromSemester={props.removeFromSemester}
-                                        updateSemester={updateSemester} />
+                                        updateSemester={updateSemester}
+                                        removeSemester={removeSemester}
+                                        preUMBC={preUMBC }
+                                    />
 
                                 );
                             })
                         }
                     </div>
-                    <Button onClick={ addSemester} variant="primary">
-                        Add Semester
-                    </Button>
+                    <div className="flex justify-center gap-2">
+                        
+                        {/*each set of curly braces check if it should show the corresponding button
+                            check for preUMBC to ensure the user cant add semesters to first section    
+                        */}
+                        {
+                            fall && !preUMBC && <Button onClick={() => addSemester(0)} variant="primary">
+                                Add Fall
+                            </Button>
+                        }
+                        {
+                            spring && !preUMBC && <Button onClick={() => addSemester(1)} variant="primary">
+                                Add Spring
+                            </Button>
+                        }
+                        {
+                            winter && !preUMBC && <Button onClick={() => addSemester(2)} variant="primary">
+                                Add Winter
+                            </Button>
+                        }
+                        {
+                            summer && !preUMBC && <Button onClick={() => addSemester(3)} variant="primary">
+                                Add Summer
+                            </Button>
+                        }
+                    </div>
+                    
+                    
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Added support for unique buttons for each semester, additionally tried to do the years but that was causing too many headaches. Added unique support for the special "semester" objects in the Before UMBC year. They will not be able to be removed

Buttons will appear when you remove a given semester.
![image](https://github.com/user-attachments/assets/ffa23bb4-b356-4716-bd43-38be7d00c20d)
