### PR TITLE
Fixed bug with course name length

### DIFF
--- a/src/components/EditCourse.js
+++ b/src/components/EditCourse.js
@@ -81,7 +81,7 @@ function EditCourse({onConfirm}) { //Takes a prop from semester which is an on c
         
         
       
-          <select value={selectedCourse?.id || ''}
+          <select style={{ width: '300px' }} value={selectedCourse?.id || ''}
               onChange={(e) => {
                    const course = selectCourse.find(c => c.id === e.target.value)
                    setSelectedCourse(course)


### PR DESCRIPTION
Added width constraint so that the course name doesn't expand past the edge of the component. When the window gets smaller it still works with the flex box, just moves to a new line below the department selection